### PR TITLE
Update VATSIM PHP Version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
       }
     ],
     "require": {
-        "skymeyer/vatsimphp": "1.0.*"
+        "skymeyer/vatsimphp": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Updating VATSIM PHP to use `^2.0`. This will ensure compatibility with Laravel 7 and above.