### PR TITLE
Allow for Guzzle v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "php": ">=7.2",
     "skymeyer/vatsimphp": "^2.0",
-    "guzzlehttp/guzzle": "^6.5"
+    "guzzlehttp/guzzle": "^6.5|^7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5",


### PR DESCRIPTION
Updates `composer.json` to allow for the use of Guzzle v7.
Tests pass on both v6 and v7.